### PR TITLE
Feature | #41 | @seogwoojin | 인증/인가 추가

### DIFF
--- a/prography-bff/build.gradle.kts
+++ b/prography-bff/build.gradle.kts
@@ -44,6 +44,15 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    // 모킹 테스트
+    testImplementation("org.mockito:mockito-core:5.5.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(group = "org.mockito", module = "mockito-core") // 버전 충돌 방지용
+    }
+
+    testImplementation("com.h2database:h2:2.2.220")
 }
 
 allOpen {

--- a/prography-bff/src/main/kotlin/org/prography/bff/auth/domain/service/OAuthLoginService.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/auth/domain/service/OAuthLoginService.kt
@@ -4,6 +4,7 @@ import org.prography.bff.auth.domain.model.LoginDto
 import org.prography.bff.auth.domain.model.TokenType
 import org.prography.bff.auth.domain.port.OAuthProvider
 import org.prography.bff.config.exception.notfound.NotFoundException
+import org.prography.bff.config.security.JwtProvider
 import org.prography.bff.user.domain.entity.Provider
 import org.prography.bff.user.domain.service.UserService
 import org.springframework.stereotype.Service

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/BaseTimeEntity.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/BaseTimeEntity.kt
@@ -1,0 +1,20 @@
+package org.prography.bff.config
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreationTimestamp
+    @Column(updatable = false)
+    lateinit var createdAt: LocalDateTime
+
+    @UpdateTimestamp
+    lateinit var updatedAt: LocalDateTime
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/CorsConfig.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/CorsConfig.kt
@@ -1,4 +1,4 @@
-package org.prography.config
+package org.prography.bff.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/CustomFilterConfig.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/CustomFilterConfig.kt
@@ -1,0 +1,35 @@
+package org.prography.bff.config
+
+import org.prography.bff.config.security.AuthenticationFilter
+import org.prography.bff.config.security.AuthorizationFilter
+import org.prography.bff.config.security.JwtProvider
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CustomFilterConfig {
+    @Bean
+    fun authenticationFilter(jwtProvider: JwtProvider): FilterRegistrationBean<AuthenticationFilter> {
+        val registration = FilterRegistrationBean(AuthenticationFilter(jwtProvider))
+        registration.addUrlPatterns("/*")
+        registration.order = 1
+        return registration
+    }
+
+    /**
+     * Security URI에 대한 권한을 결정
+     */
+    @Bean
+    fun authorizationFilter(): FilterRegistrationBean<AuthorizationFilter> {
+        val uriRoleMap =
+            mapOf(
+                "/users/me" to listOf("USER"),
+            )
+
+        return FilterRegistrationBean(AuthorizationFilter(uriRoleMap)).apply {
+            order = 2
+            addUrlPatterns("/*")
+        }
+    }
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/JpaConfig.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/JpaConfig.kt
@@ -1,0 +1,8 @@
+package org.prography.bff.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfig

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/SwaggerConfig.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/SwaggerConfig.kt
@@ -2,11 +2,18 @@ package org.prography.bff.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.core.jackson.ModelResolver
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
+import org.prography.bff.config.security.AuthUser
+import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.HandlerMethod
 
 // Todo : Swagger UI에 JWT Bearer 입력 필드를 추가하는 설정, 로그인 구현 후 적용
 // @SecurityScheme(
@@ -41,11 +48,49 @@ class SwaggerConfig {
                 .url("http://localhost:8080")
                 .description("Local 서버")
 
+        // JWT Security Scheme 정의
+        val jwtSecurityScheme =
+            SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .`in`(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .description("JWT Bearer Token")
+
         return OpenAPI()
             .info(info)
             .servers(listOf(httpsServer, localServer))
+            .components(
+                Components().addSecuritySchemes("JWT", jwtSecurityScheme),
+            )
+            .addSecurityItem(
+                SecurityRequirement().addList("JWT"),
+            )
     }
 
     @Bean
     fun modelResolver(objectMapper: ObjectMapper) = ModelResolver(objectMapper)
+
+    /**
+     * 유저 커스텀 어노테이션을 스웨거가 인지하지 못하도록 수정
+     */
+    @Bean
+    fun ignoreAuthenticatedUserAnnotation(): OperationCustomizer {
+        return OperationCustomizer { operation: Operation, handlerMethod: HandlerMethod ->
+
+            // Java 리플렉션으로 실제 파라미터 확인
+            val methodParameters = handlerMethod.method.parameters
+
+            val filteredParameters =
+                operation.parameters?.filterIndexed { index, _ ->
+                    val param = methodParameters.getOrNull(index)
+                    // @AuthUser 어노테이션이 붙지 않은 경우만 유지
+                    param?.getAnnotation(AuthUser::class.java) == null
+                }
+
+            operation.parameters = filteredParameters
+            operation
+        }
+    }
 }

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/WebConfig.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/WebConfig.kt
@@ -1,0 +1,13 @@
+package org.prography.bff.config
+
+import org.prography.bff.config.security.AuthenticatedUserArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(AuthenticatedUserArgumentResolver())
+    }
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/exception/badrequest/InvalidRequestException.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/exception/badrequest/InvalidRequestException.kt
@@ -2,4 +2,6 @@ package org.prography.bff.config.exception.badrequest
 
 sealed class InvalidRequestException(
     override val message: String,
-) : RuntimeException(message)
+) : RuntimeException(message) {
+    class InvalidTokenException : InvalidRequestException("유저 ID를 찾지 못했습니다.")
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/exception/notfound/NotFoundException.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/exception/notfound/NotFoundException.kt
@@ -8,4 +8,6 @@ sealed class NotFoundException(
     class PlaceInfoNotFoundException : NotFoundException("해당 식당의 정보가 수집되지 않았습니다.")
 
     class ProviderNotFoundException : NotFoundException("지원하지 않는 제공자입니다.")
+
+    class UserNotFoundException : NotFoundException("유저 정보가 없습니다.")
 }

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthUser.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthUser.kt
@@ -1,0 +1,17 @@
+package org.prography.bff.config.security
+
+/**
+ * 컨트롤러 메서드의 파라미터에 붙여,
+ * JWT 필터에서 request attribute로 저장한 사용자 ID(UUID)를 주입받기 위한 어노테이션입니다.
+ *
+ * 사용 예:
+ * ```
+ * fun getProfile(@AuthUser userId: UUID): ResponseEntity<...>
+ * ```
+ *
+ * 해당 파라미터는 UUID 타입이어야 하며,
+ * 필터에서 `request.setAttribute("userId", userId)`로 저장된 값이 필요합니다.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuthUser

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticatedUserArgumentResolver.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticatedUserArgumentResolver.kt
@@ -1,0 +1,27 @@
+package org.prography.bff.config.security
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import java.util.*
+
+class AuthenticatedUserArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.getParameterAnnotation(AuthUser::class.java) != null &&
+            parameter.parameterType == UUID::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Any {
+        val request = webRequest.nativeRequest as HttpServletRequest
+        return request.getAttribute("userId")
+            ?: throw IllegalStateException("userId not found in request")
+    }
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticatedUserArgumentResolver.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticatedUserArgumentResolver.kt
@@ -1,6 +1,7 @@
 package org.prography.bff.config.security
 
 import jakarta.servlet.http.HttpServletRequest
+import org.prography.bff.config.exception.badrequest.InvalidRequestException
 import org.springframework.core.MethodParameter
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
@@ -22,6 +23,6 @@ class AuthenticatedUserArgumentResolver : HandlerMethodArgumentResolver {
     ): Any {
         val request = webRequest.nativeRequest as HttpServletRequest
         return request.getAttribute("userId")
-            ?: throw IllegalStateException("userId not found in request")
+            ?: throw InvalidRequestException.InvalidTokenException()
     }
 }

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticationFilter.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticationFilter.kt
@@ -1,0 +1,62 @@
+package org.prography.bff.config.security
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import java.time.LocalDateTime
+
+class AuthenticationFilter(
+    private val jwtProvider: JwtProvider,
+) : Filter {
+    private val objectMapper = jacksonObjectMapper()
+
+    /**
+     * Token이 존재하며 유효하다면 Request에 payload 저장,
+     * 없다면 다음 필터로
+     */
+    override fun doFilter(
+        request: ServletRequest,
+        response: ServletResponse,
+        chain: FilterChain,
+    ) {
+        val httpRequest = request as HttpServletRequest
+        val httpResponse = response as HttpServletResponse
+
+        val token = extractToken(httpRequest)
+
+        if (token != null && !jwtProvider.validateToken(token)) {
+            val errorBody =
+                mapOf(
+                    "error" to "잘못된 토큰 형식입니다.",
+                    "time" to LocalDateTime.now().toString(),
+                )
+
+            val json = objectMapper.writeValueAsString(errorBody)
+            httpResponse.contentType = "application/json;charset=UTF-8"
+            httpResponse.writer.write(json)
+            return
+        }
+
+        // 토큰이 존재하는 경우에 주입
+        token?.let {
+            val userId = jwtProvider.getUserId(token)
+            request.setAttribute("userId", userId)
+            request.setAttribute("role", "USER")
+        }
+
+        chain.doFilter(request, response)
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val header = request.getHeader("Authorization")
+        return if (header != null && header.startsWith("Bearer ")) {
+            header.substring(7)
+        } else {
+            null
+        }
+    }
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticationFilter.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthenticationFilter.kt
@@ -37,6 +37,7 @@ class AuthenticationFilter(
 
             val json = objectMapper.writeValueAsString(errorBody)
             httpResponse.contentType = "application/json;charset=UTF-8"
+            httpResponse.status = HttpServletResponse.SC_UNAUTHORIZED
             httpResponse.writer.write(json)
             return
         }

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthorizationFilter.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthorizationFilter.kt
@@ -1,0 +1,58 @@
+package org.prography.bff.config.security
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import java.time.LocalDateTime
+
+class AuthorizationFilter(
+    private val uriRoleMap: Map<String, List<String>>,
+) : Filter {
+    private val objectMapper = jacksonObjectMapper()
+
+    override fun doFilter(
+        request: ServletRequest,
+        response: ServletResponse,
+        chain: FilterChain,
+    ) {
+        val httpRequest = request as HttpServletRequest
+        val httpResponse = response as HttpServletResponse
+
+        val path = httpRequest.requestURI
+        val requiredRoles = getRequiredRoles(path)
+        val userRole = request.getAttribute("role") as? String
+
+        // 인가 확인
+        val authorized = requiredRoles.isEmpty() || userRole in requiredRoles
+
+        if (!authorized) {
+            val errorBody =
+                mapOf(
+                    "error" to "접근 권한이 없는 유저입니다.",
+                    "time" to LocalDateTime.now().toString(),
+                )
+
+            val json = objectMapper.writeValueAsString(errorBody)
+            httpResponse.contentType = "application/json;charset=UTF-8"
+            httpResponse.writer.write(json)
+            return
+        }
+
+        chain.doFilter(request, response)
+    }
+
+    /**
+     * 경로 기반 Role 매핑 조회
+     * - URI가 시작되는 prefix 기준으로 매칭
+     * - 가장 먼저 일치하는 엔트리를 반환
+     */
+    private fun getRequiredRoles(path: String): List<String> {
+        return uriRoleMap.entries
+            .find { path.startsWith(it.key) }
+            ?.value ?: emptyList()
+    }
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthorizationFilter.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/AuthorizationFilter.kt
@@ -38,6 +38,7 @@ class AuthorizationFilter(
 
             val json = objectMapper.writeValueAsString(errorBody)
             httpResponse.contentType = "application/json;charset=UTF-8"
+            httpResponse.status = HttpServletResponse.SC_FORBIDDEN
             httpResponse.writer.write(json)
             return
         }

--- a/prography-bff/src/main/kotlin/org/prography/bff/config/security/JwtProvider.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/config/security/JwtProvider.kt
@@ -1,4 +1,4 @@
-package org.prography.bff.auth.domain.service
+package org.prography.bff.config.security
 
 import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/controller/UserController.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/controller/UserController.kt
@@ -1,0 +1,32 @@
+package org.prography.bff.user.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import org.prography.bff.config.response.ApiResponse
+import org.prography.bff.user.controller.model.UserInfoResponseDto
+import java.util.*
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+interface UserController {
+    @Operation(
+        summary = "내 정보 조회 API",
+        description = "JWT 인증된 사용자의 정보를 반환합니다.",
+        responses = [
+            SwaggerApiResponse(
+                responseCode = "200",
+                description = "성공",
+                content = [Content(schema = Schema(implementation = UserInfoResponseDto::class))],
+            ),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "인가 실패",
+            ),
+        ],
+    )
+    fun getMyInfo(userId: UUID): ApiResponse<UserInfoResponseDto>
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/controller/UserControllerImpl.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/controller/UserControllerImpl.kt
@@ -1,0 +1,30 @@
+package org.prography.bff.user.controller
+
+import org.prography.bff.config.response.ApiResponse
+import org.prography.bff.config.security.AuthUser
+import org.prography.bff.user.controller.model.UserInfoResponseDto
+import org.prography.bff.user.domain.service.UserService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+
+@RestController
+@RequestMapping("/users")
+class UserControllerImpl(private val userService: UserService) : UserController {
+    @GetMapping("/me")
+    override fun getMyInfo(
+        @AuthUser userId: UUID,
+    ): ApiResponse<UserInfoResponseDto> {
+        val userInfo = userService.getUserInfo(userId)
+        val response =
+            UserInfoResponseDto(
+                userInfo.userId,
+                userInfo.provider,
+                userInfo.nickname,
+                userInfo.level,
+                userInfo.createdAt,
+            )
+        return ApiResponse.success(response)
+    }
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/controller/model/UserInfoResponseDto.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/controller/model/UserInfoResponseDto.kt
@@ -1,0 +1,13 @@
+package org.prography.bff.user.controller.model
+
+import org.prography.bff.user.domain.entity.Provider
+import java.time.LocalDateTime
+import java.util.*
+
+data class UserInfoResponseDto(
+    val userId: UUID,
+    val provider: Provider,
+    val nickname: String,
+    val level: Int,
+    val createdAt: LocalDateTime,
+)

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/domain/entity/User.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/domain/entity/User.kt
@@ -1,11 +1,16 @@
 package org.prography.bff.user.domain.entity
 
 import jakarta.persistence.*
+import org.prography.bff.config.BaseTimeEntity
 import java.util.*
 
 @Entity
 @Table(name = "users")
-class User(provider: Provider, providerId: String, nickname: String) {
+class User(
+    provider: Provider,
+    providerId: String,
+    nickname: String,
+) : BaseTimeEntity() {
     @Id
     val id: UUID = UUID.randomUUID()
 
@@ -16,4 +21,8 @@ class User(provider: Provider, providerId: String, nickname: String) {
 
     var nickname: String = nickname
         protected set
+
+    var level: Int = 0
+
+    var status: Boolean = false
 }

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/domain/repository/UserRepository.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/domain/repository/UserRepository.kt
@@ -3,8 +3,9 @@ package org.prography.bff.user.domain.repository
 import org.prography.bff.user.domain.entity.Provider
 import org.prography.bff.user.domain.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
-interface UserRepository : JpaRepository<User, Long> {
+interface UserRepository : JpaRepository<User, UUID> {
     fun findByProviderAndProviderId(
         provider: Provider,
         providerId: String,

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/domain/service/NicknameGenerator.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/domain/service/NicknameGenerator.kt
@@ -1,0 +1,65 @@
+package org.prography.bff.user.domain.service
+
+import kotlin.random.Random
+
+object NicknameGenerator {
+    private val foodList =
+        listOf(
+            "떡볶이",
+            "짜장면",
+            "김밥",
+            "비빔밥",
+            "불고기",
+            "삼겹살",
+            "치킨",
+            "피자",
+            "라면",
+            "순두부",
+            "된장찌개",
+            "김치찌개",
+            "갈비탕",
+            "설렁탕",
+            "냉면",
+            "칼국수",
+            "쌀국수",
+            "돈까스",
+            "우동",
+            "초밥",
+            "오므라이스",
+            "햄버거",
+            "파스타",
+            "스테이크",
+            "샐러드",
+            "감자탕",
+            "족발",
+            "보쌈",
+            "닭갈비",
+            "쭈꾸미",
+            "곱창",
+            "막창",
+            "순대",
+            "튀김",
+            "만두",
+            "잡채",
+            "해물파전",
+            "부대찌개",
+            "토스트",
+            "샌드위치",
+            "탕수육",
+            "양념치킨",
+            "후라이드치킨",
+            "마라탕",
+            "훠궈",
+            "양꼬치",
+            "초계국수",
+            "콩국수",
+            "닭개장",
+            "동태찌개",
+        )
+
+    fun generate(): String {
+        val food = foodList.random()
+        val number = Random.nextInt(0, 10000).toString().padStart(4, '0')
+        return "$food$number"
+    }
+}

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/domain/service/UserService.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/domain/service/UserService.kt
@@ -1,10 +1,14 @@
 package org.prography.bff.user.domain.service
 
+import org.prography.bff.config.exception.notfound.NotFoundException
 import org.prography.bff.user.domain.entity.Provider
 import org.prography.bff.user.domain.entity.User
 import org.prography.bff.user.domain.repository.UserRepository
+import org.prography.bff.user.domain.service.model.UserInfoDto
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @Service
 @Transactional
@@ -20,8 +24,15 @@ class UserService(
                 User(
                     provider = provider,
                     providerId = providerId,
-                    nickname = "익명",
+                    nickname = NicknameGenerator.generate(),
                 ),
             )
+    }
+
+    fun getUserInfo(userId: UUID): UserInfoDto {
+        val user =
+            userRepository.findByIdOrNull(userId) ?: throw NotFoundException.UserNotFoundException()
+
+        return UserInfoDto.fromUser(user)
     }
 }

--- a/prography-bff/src/main/kotlin/org/prography/bff/user/domain/service/model/UserInfoDto.kt
+++ b/prography-bff/src/main/kotlin/org/prography/bff/user/domain/service/model/UserInfoDto.kt
@@ -1,0 +1,26 @@
+package org.prography.bff.user.domain.service.model
+
+import org.prography.bff.user.domain.entity.Provider
+import org.prography.bff.user.domain.entity.User
+import java.time.LocalDateTime
+import java.util.*
+
+data class UserInfoDto(
+    val userId: UUID,
+    val provider: Provider,
+    val nickname: String,
+    val level: Int,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun fromUser(user: User): UserInfoDto {
+            return UserInfoDto(
+                user.id,
+                user.provider,
+                user.nickname,
+                user.level,
+                user.createdAt,
+            )
+        }
+    }
+}

--- a/prography-bff/src/test/kotlin/org/prography/bff/config/security/AuthFilterTests.kt
+++ b/prography-bff/src/test/kotlin/org/prography/bff/config/security/AuthFilterTests.kt
@@ -1,0 +1,72 @@
+package org.prography.bff.config.security
+
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.prography.bff.auth.domain.model.TokenType
+import org.prography.bff.user.domain.entity.Provider
+import org.prography.bff.user.domain.entity.User
+import org.prography.bff.user.domain.repository.UserRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class AuthFilterTests(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val jwtProvider: JwtProvider,
+    @Autowired val userRepository: UserRepository,
+) {
+    private lateinit var accessToken: String
+
+    @BeforeEach
+    fun setup() {
+        val user =
+            userRepository.save(
+                User(
+                    provider = Provider.KAKAO,
+                    providerId = "test",
+                    nickname = "돼지고기1234",
+                ),
+            )
+
+        accessToken =
+            jwtProvider.createToken(
+                tokenType = TokenType.ACCESS_TOKEN,
+                subject = user.id.toString(),
+            )
+    }
+
+    @Test
+    fun `valid token passes authentication and authorization`() {
+        mockMvc.perform(
+            get("/users/me")
+                .header("Authorization", "Bearer $accessToken"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string(Matchers.containsString("돼지고기1234")))
+    }
+
+    @Test
+    fun `missing token returns unauthorized`() {
+        mockMvc.perform(get("/users/me"))
+            .andExpect(status().isForbidden)
+            .andExpect(content().string(Matchers.containsString("접근 권한이 없는 유저입니다.")))
+    }
+
+    @Test
+    fun `invalid token returns unauthorized`() {
+        mockMvc.perform(
+            get("/users/me")
+                .header("Authorization", "Bearer invalid.token.here"),
+        )
+            .andExpect(status().isUnauthorized)
+    }
+}

--- a/prography-bff/src/test/resources/application-test.yml
+++ b/prography-bff/src/test/resources/application-test.yml
@@ -1,0 +1,45 @@
+server:
+  port: 8081  # 테스트용 포트 변경 가능
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/testdb_local
+    elasticsearch:
+      host: localhost
+      port: 9200
+      user: elastic
+      password: changeme
+      ssl:
+        enable: true
+        trust-all: true
+      repositories:
+        enabled: false
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
+jwt:
+  secret: test-secret-key-for-jwt-which-should-be-long-enough
+  access-expiration: 60000       # 1분
+  refresh-expiration: 3600000    # 1시간
+
+kakao:
+  client-id: test-client-id
+  redirect-uri: http://localhost:8081/oauth/kakao/callback
+  client-secret: test-client-secret
+
+naver:
+  client-id: test-client-id
+  client-secret: test-client-secret


### PR DESCRIPTION
## 📌 관련 이슈 번호 (필수)

<!-- 예: Closes #123, Fixes #45 -->
Close #41 

- [예시 링크 이름](https://example.com)

---

## ✨ 변경 내용 요약 (필수)

<!-- 주요 수정 사항을 간단히 작성해주세요 -->
- 커스텀 필터 기반 인증 / 인가를 구현했습니다.
- 커스텀 어노테이션을 활용해 유저 UUID 정보를 토큰을 통해 가져올 수 있습니다.
- 유저 닉네임 생성 기능을 추가했습니다.

- 토큰이 없는 유저의 경우 "role"이 부여되지 않은 채 인증 필터를 통과하고, 토큰이 잘못된 토큰일 경우 401 예외를 반환합니다.
- 인가 권한이 필요한 URI에 role이 없는 유저가 접근할 경우 403 예외를 반환합니다.

---

## 리뷰 요청하고 싶은 사항 (선택)

<!-- 리뷰어에게 중점적으로 봐줬으면 하는 부분, 질문 등 -->
- 